### PR TITLE
Fix python examples with invalid markup closure tags

### DIFF
--- a/content/python/list_packages.md
+++ b/content/python/list_packages.md
@@ -76,4 +76,4 @@ if __name__ == "__main__":
     main.getPackage(126)
     main.getAllLocations()  
 
-```python
+```

--- a/content/python/token_auth.md
+++ b/content/python/token_auth.md
@@ -36,4 +36,4 @@ class tokenAuth():
 if __name__ == "__main__":
     main = tokenAuth()
     main.main()
-```python
+```


### PR DESCRIPTION
Corrected two examples with code markup sections that weren’t ended
properly resulting in display issues. This fix is to resolve #18.
