### PR TITLE
Clean up of server_locate ruby example

### DIFF
--- a/content/ruby/server_locate.md
+++ b/content/ruby/server_locate.md
@@ -1,6 +1,6 @@
 ---
 title: "Server Locate"
-description: "List specific location for virtual machines"
+description: "List specific physical location for virtual machines"
 date: "2014-09-30"
 classes: ["SoftLayer_Account"]
 tags:
@@ -15,17 +15,17 @@ tags:
 require 'softlayer_api'
 require 'table_print'
 
-softlayer_client = SoftLayer::Client.new()
-account = SoftLayer::Account.account_for_client(softlayer_client)
+SoftLayer::Client.default_client = SoftLayer::Client.new
 
-servers = SoftLayer::VirtualServer.find_servers(:client => softlayer_client, :object_mask => 'mask[location.pathString]')
+servers = SoftLayer::VirtualServer.find_servers(object_mask: 'mask[location.pathString]')
 location_info = servers.map do |server|
   datacenter, server_room, rack, slot = server['location']['pathString'].split('.')
-  { :server => server.fullyQualifiedDomainName,
-    :data_center => datacenter, 
-    :server_room => server_room, 
-    :rack => rack, 
-    :slot => slot
+  {
+    server: server.fullyQualifiedDomainName,
+    data_center: datacenter,
+    server_room: server_room,
+    rack: rack,
+    slot: slot
   }
 end
 


### PR DESCRIPTION
Just using new format for specifying keys. Removing unused variable 'account'. Removing redundant specification of the client everywhere.
