### PR TITLE
Update to comperator DevOps tooling section

### DIFF
--- a/tools/compareorator/index.html
+++ b/tools/compareorator/index.html
@@ -746,7 +746,7 @@ ga('send', 'pageview');
 <tbody>
 <tr>
 <td><a href="https://console.ng.bluemix.net/catalog/services/active-deploy/">Active Deploy </a></td>
-<td>OpsWorks CloudFormation</td>
+<td>AWS CodeDeploy / OpsWorks CloudFormation</td>
 <td>Resource Manager Automation</td>
 </tr>
 
@@ -770,7 +770,7 @@ ga('send', 'pageview');
 
 <tr>
 <td><a href="https://console.ng.bluemix.net/catalog/services/delivery-pipeline/">Delivery Pipeline</a></td>
-<td>N/A</td>
+<td>AWS CodePipeline</td>
 <td>N/A</td>
 </tr>
 


### PR DESCRIPTION
The comperator page seems to be outdated. This is an update for the Delivery Pipeline service mapping, more to come